### PR TITLE
enhancement: add error page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN useradd --user-group --create-home \
 
 RUN mkdir -p /opt/multi && chown app /opt/multi
 ADD . /app
+ADD errors/5xx.html /usr/share/nginx/html/5xx.html
 
 # VOLUME ["/etc/nginx", "/app"]
 

--- a/errors/5xx.html
+++ b/errors/5xx.html
@@ -1,0 +1,8 @@
+<html>
+	<head>
+	<title>Error</title>
+	</head>
+	<body>
+		<h1>Fail example</h1>
+	</body>
+</html>

--- a/errors/5xx.html
+++ b/errors/5xx.html
@@ -3,6 +3,6 @@
 	<title>Error</title>
 	</head>
 	<body>
-		<h1>Fail example</h1>
+		<h1>Your Personal Nightscout site is reloading. Please try again in a few minutes</h1>
 	</body>
 </html>

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -212,5 +212,11 @@ http {
       proxy_pass $tenant$request_uri;
 
     }
+    #Handle 5xx errors with sorry page
+    error_page 500 502 503 504 /5xx.html;
+    location = /5xx.html {
+      root /usr/share/nginx/html;
+      internal;
+    }
   }
 }


### PR DESCRIPTION
This change allows NGINX to serve an error page if the tenant is not
found in consul.