### PR TITLE
enable most available election for clusters

### DIFF
--- a/start_container.sh
+++ b/start_container.sh
@@ -9,6 +9,9 @@ ls -alh /etc/nginx
 export INTERNAL_PORT=3434
 export REDIRECTOR_PORT=3636
 export RESOLVER_IP=$(dig +short consul.service.consul | ( read ip; test -z "$ip" && echo 8.8.8.8 || echo $ip:8600))
+SUGGESTED_MAX=$(awk '/MemFree/ { printf "%.3f \n", $2/1024/1024/0.050 }' /proc/meminfo)
+export MAX_TENANT_LIMIT=${MAX_TENANT_LIMIT-$SUGGESTED_MAX}
+
 
 export PORT=4545
 

--- a/tenant-availability-keeper.js
+++ b/tenant-availability-keeper.js
@@ -18,8 +18,9 @@ function configureServer (opts, ctx) {
 
   function apply_policies (services) {
     function byTotalActive (x) { return x.HealthStatus.total.active; }
+    function byCapacityQuotient (x) { return x.HealthStatus.total.expected / x.HealthStatus.total.max; }
     function hasHealth (x) { return x && x.HealthStatus; }
-    return _.sortBy(services.filter(hasHealth), byTotalActive);
+    return _.sortBy(services.filter(hasHealth), byCapacityQuotient);
   }
 
   function require_health (services, next) {


### PR DESCRIPTION
This allows the demuxer interface to elect the most available runner from a
fleet of runners.  Previously, the runner with least active tenants would be
elected.  This change introduces a "capacity quotient" which is the total known
tenants divided by the max allowed tenant.  Experience indicates that among a
fleet of runners, often the most loaded runner will have the fewest active
tenants, even though the expected total number is much larger.  In scenarios
like those, this change should help avoid those ailing runners.