### PR TITLE
Wip/bewest/offset synchronizations

### DIFF
--- a/k8s-dispatcher.js
+++ b/k8s-dispatcher.js
@@ -132,7 +132,6 @@ function inspectBookmarks (opts, k8s) {
       console.log("EXPIRED resourceVersion", chunk);
       return k8s.readNamespacedConfigMap(bookmarkName, bookmarkNamespace).then(function (result) {
         console.log('EXISTING BOOKMARK equivalent?', opts, opts.resourceVersion, result.body.data.resourceVersion, opts.resourceVersion == result.body.data.resourceVersion);
-        var err.bookmark = result.body;
         console.log('EXISTING BOOKMARK', result.body);
         if (deleteStaleBookmark) {
           return k8s.deleteNamespacedConfigMap(bookmarkName, bookmarkNamespace).then(function (result) {

--- a/k8s-dispatcher.js
+++ b/k8s-dispatcher.js
@@ -301,7 +301,7 @@ if (!module.parent) {
         naiveGetFromGateway(gateway_opts),
         post( ), console.log.bind(console, 'STREAM ENDED'));
     }).catch(function (err) {
-       boot.fail(err);
+      boot.fail(err);
     });
   });
 }

--- a/k8s-dispatcher.js
+++ b/k8s-dispatcher.js
@@ -136,6 +136,7 @@ function saveBookMark (opts, k8s) {
       var body = result.body;
       console.log("OLD BOOKMARK", body);
       body.data.resourceVersion = chunk.object.metadata.resourceVersion;
+      body.data.WATCH_RESOURCEVERSION = chunk.object.metadata.resourceVersion;
       return k8s.replaceNamespacedConfigMap(bookmarkName, bookmarkNamespace, body).then(function (result) {
         console.log("SAVED NEW BOOKMARK", bookmarkName, bookmarkNamespace, result.body);
         return callback( );
@@ -153,7 +154,8 @@ function saveBookMark (opts, k8s) {
           type: 'BOOKMARK'
         },
         data: {
-          resourceVersion: watch_opts.resourceVersion || '0'
+          resourceVersion: chunk.object.metadata.resourceVersion
+        , WATCH_RESOURCEVERSION:  chunk.object.metadata.resourceVersion
         }
 
       };
@@ -246,7 +248,7 @@ if (!module.parent) {
   var WATCH_NAMESPACE = process.env.MULTIENV_K8S_NAMESPACE || 'default';
   var WATCH_ENDPOINT = process.env.WATCH_ENDPOINT || ('/api/v1/namespaces/' + WATCH_NAMESPACE + '/configmaps');
   var WATCH_FIELDSELECTOR = process.env.WATCH_FIELDSELECTOR || '';
-  var WATCH_LABELSELECTOR = process.env.WATCH_LABELSELECTOR || '';
+  var WATCH_LABELSELECTOR = process.env.WATCH_LABELSELECTOR || 'app=tenant,managed=multienv';
   var WATCH_RESOURCEVERSION = process.env.WATCH_RESOURCEVERSION || '';
   var WATCH_CONTINUE = process.env.WATCH_CONTINUE || '';
   var gateway_opts = {

--- a/k8s-dispatcher.js
+++ b/k8s-dispatcher.js
@@ -362,11 +362,11 @@ if (!module.parent) {
                 watch_opts.resourceVersion = '';
                 bookmark_config.resourceVersion = '';
                 console.log("Retrying without resourceVersion", watch_opts);
+                errors.push(err);
+                console.log('restarting...');
+                return start(retried + 1, max, errors);
               }
-              errors.push(err);
             }
-            console.log('restarting...');
-            return start(retried + 1, max, errors);
           }
           );
       }).catch(function (err) {

--- a/k8s-dispatcher.js
+++ b/k8s-dispatcher.js
@@ -275,7 +275,7 @@ if (!module.parent) {
 
   var bookmark_config = {
     bookmarkName: process.env.BOOKMARK_NAME || 'dispatcher-bookmark'
-  , bookmarkNamespace: process.env.BOOKMARK_NAMESPACE || 'default'
+  , bookmarkNamespace: WATCH_NAMESPACE
 
   }
 

--- a/k8s-dispatcher.js
+++ b/k8s-dispatcher.js
@@ -124,15 +124,8 @@ function saveBookMark (opts, k8s) {
       return callback( );
     }
 
-    console.log(chunk);
-    console.log("SAVING BOOKMARK");
-    var patch = {
-      data: {
-        resourceVersion: chunk.object.metadata.resourceVersion
-      }
-
-    };
-    k8s.readNamespacedConfigMap(bookmarkName, bookmarkNamespace, patch).then(function (result) {
+    console.log("SAVING BOOKMARK", chunk);
+    k8s.readNamespacedConfigMap(bookmarkName, bookmarkNamespace).then(function (result) {
       var body = result.body;
       console.log("OLD BOOKMARK", body);
       body.data.resourceVersion = chunk.object.metadata.resourceVersion;

--- a/master.js
+++ b/master.js
@@ -5,7 +5,6 @@ var cluster = require('cluster');
 var path = require('path');
 var glob = require('glob');
 var fs = require('fs');
-var watch = require('watch');
 var chokidar = require('chokidar');
 var shlex = require('shell-quote');
 var Server = require('./server');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Ben West <bewest@gmail.com>",
   "license": "AGPLv3",
   "dependencies": {
-    "@kubernetes/client-node": "^0.12.0",
+    "@kubernetes/client-node": "^0.18.1",
     "async": "^3.2.0",
     "bootevent": "0.0.1",
     "bunyan": "^1.4.0",
@@ -20,8 +20,6 @@
     "consul": "^0.34.1",
     "debounce": "^1.0.0",
     "dotenv": "github:motdotla/dotenv#838e89e",
-    "foreman": "^3.0.1",
-    "forever-monitor": "^1.5.2",
     "glob": "^7.2.0",
     "got": "^11.5.2",
     "hashids": "^1.2.2",
@@ -31,8 +29,7 @@
     "pm2": "^4.4.0",
     "restify": "^8.5.1",
     "shell-escape": "^0.2.0",
-    "tmp": "0.0.26",
-    "watch": "^0.13.0"
+    "tmp": "0.0.26"
   },
   "repository": {
     "type": "git",

--- a/start_container.sh
+++ b/start_container.sh
@@ -83,7 +83,7 @@ case "${1-help}" in
     exec -a inspector $RUNTIME --no-autorestart --exp-backoff-restart-delay=100 -i max k8s-inspector.js
   ;;
   dispatcher)
-    exec -a dispatcher $RUNTIME --no-autorestart --exp-backoff-restart-delay=100 k8s-dispatcher.js
+    exec -a dispatcher node k8s-dispatcher.js
   ;;
   demuxer)
     exec -a demuxer $RUNTIME --no-autorestart --exp-backoff-restart-delay=100 -i max tenant-availability-keeper.js


### PR DESCRIPTION
A follow up to dispatchers based on experience with operations.  In practice, this means that for a group of ~1k tenants, the system take ~20 minutes to sweep through the entire batch of tenants.  Any change occurring during that window will have to wait for the entire backlog to sweep through before the change can propagate.  This creates unwieldy delays when using the dashboard or settling accounts.  These changes allow inserting the bookmark event into a configmap, and then reading the bookmark from the configmap back in to resume during the startup sequence.  So long dispatchers restarts within a reasonable amount of time, it will resume where it left off instead of having kubernetes stream the entire inventory.  In addition, labels should be used by default in order pull configmaps of interest rather than having to filter out unwanted configmaps.  In addition, this more easily allows dispatcher to monitor wanted configmaps while ignoring changes to its own configmap safely.  The final impact is that there should be no regular massive sweep causing all Nightscout instances to restart at the same time.