### PR TITLE
dispatchers should not get stuck initializing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "Ben West <bewest@gmail.com>",
   "license": "AGPLv3",
   "dependencies": {
-    "@kubernetes/client-node": "^0.18.1",
+    "@kubernetes/client-node": "^0.19.0",
     "async": "^3.2.0",
     "bootevent": "0.0.1",
     "bunyan": "^1.4.0",
@@ -30,7 +30,8 @@
     "restify": "^8.5.1",
     "shell-escape": "^0.2.0",
     "shell-quote": "^1.8.0",
-    "tmp": "0.0.26"
+    "tmp": "0.0.26",
+    "underscore": "^1.13.6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Over the last 4 months something changed in the way dispatcher received BOOKMARKs from Kubernetes Watch.  The k8s documentation indicates that under certain conditions a watch command not filtered by resourceVersion will generate synthetic ADD events for all items matched by the selector followed by a BOOKMARK with the current resourceVersion.  Over the last 4 months this behavior stopped, and after all ADD events, no BOOKMARKs are ever received anymore.

This has the effect of restarting all Nightscout tenants in an endless loop while all the ADD events are restarting the runner in clusters.  Without any BOOKMARKs, the process dies, restarts and again processes all ADD events against clusters endpoints.  This causes needless churn on operationally healthy Nightscout instances and uses more compute resources as a result.

This change restructures the design of dispatcher such that it will ignore BOOKMARKs except for auditing purposes.  When the process starts, it will perform a quick LIST operation to learn the current resourceVersion, and then start the watch using this version.  The k8s docs indicate a LIST+WATCH pattern, and it allows removing some complicated code to handle the stateful bookmarks.