### PR TITLE
remove experimental code

### DIFF
--- a/k8s-dispatcher.js
+++ b/k8s-dispatcher.js
@@ -58,10 +58,6 @@ function naivePostToGateway (opts) {
 
     data.internal_name = name;
     console.log(name, 'to gateway', name, api, object.metadata.name, object.metadata.resourceVersion);
-    if (update.type != 'MODIFIED') {
-      console.log("SKIPPED", name, update.type);
-      return callback(null, update);
-    }
     method(api, {json: data}).json( ).then( function (body) {
       console.log(name, 'SUCCESSFUL', api);
       update.gateway = {err: null, success: body};


### PR DESCRIPTION
The code removed was experimental to help handle processing large numbers of bookmarks when the process initializes.  It was not intended to be used in production.  Removing this code allows the dispatcher to handle ADD and MODIFIED events, as well as DELETE events.